### PR TITLE
Select same language for all tabs when language is selected on one tab.

### DIFF
--- a/grappelli_modeltranslation/static/grappelli_modeltranslation/js/tabbed_translation_fields.js
+++ b/grappelli_modeltranslation/static/grappelli_modeltranslation/js/tabbed_translation_fields.js
@@ -228,6 +228,12 @@
                             container.find('script').remove();
                             panel = $('<div id="' + id + '"></div>').append(container);
                             tab = $('<li' + (label.hasClass('required') ? ' class="required"' : '') + '><a href="#' + id + '">' + lang + '</a></li>');
+                            tab.bind('click', function() {
+                                var val = tabs_container.tabs('option', 'active');
+                                $(tabs).each(function(i, tab) {
+                                    tab.tabs('option', 'active', val);
+                                });
+                            });
                             tabs_list.append(tab);
                             tabs_container.append(panel);
                         }


### PR DESCRIPTION
Saves having to select the same language for every field.
