### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # grappelli-modeltranslation
-[![PyPI version](https://pypip.in/v/grappelli-modeltranslation/badge.png)](https://pypi.python.org/pypi/grappelli-modeltranslation)
+[![PyPI version](https://img.shields.io/pypi/v/grappelli-modeltranslation.svg)](https://pypi.python.org/pypi/grappelli-modeltranslation)
 
 **A small compatibility layer between django-grappelli and django-modeltranslation.**
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20grappelli-modeltranslation))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `grappelli-modeltranslation`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.