### PR TITLE
Fix incorrect language replacement in label text (ex. FileField)

### DIFF
--- a/grappelli_modeltranslation/static/grappelli_modeltranslation/js/tabbed_translation_fields.js
+++ b/grappelli_modeltranslation/static/grappelli_modeltranslation/js/tabbed_translation_fields.js
@@ -217,7 +217,12 @@
                             // Remove language and brackets from field label, they are
                             // displayed in the tab already.
                             if (field_label.html()) {
-                                field_label.html(field_label.html().replace(/\ \[.+\]/, ''));
+                                const _lang_text = '[' + lang + ']';
+                                field_label.each(function(){
+                                  let $this = $(this);
+                                  let _label = $this.html();
+                                  if (_label.includes(_lang_text)) $this.html(_label.replace(_lang_text, '').trim());
+                                })
                             }
                             if (!insertion_point) {
                                 insertion_point = {


### PR DESCRIPTION
Wrong line in old code:

`field_label.html(field_label.html().replace(/\ \[.+\]/, ''));`

But field_label - is a jquery collection and `field_label.html()` - is HTML in first element on jquery collection. As a result, all label elements are replaced with the text in the first element. Because a container can contain more than one label. 